### PR TITLE
Python3 compatibility for Base64ImageField

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -21,6 +21,23 @@ ALLOWED_IMAGE_TYPES = (
 
 EMPTY_VALUES = (None, '', [], (), {})
 
+# Python 3 Compatibility
+# Issue: basestring in Python3 raises a NameError exception!
+import types
+try:
+    unicode = unicode
+except NameError:
+    # 'unicode' is undefined, must be Python 3
+    str = str
+    unicode = str
+    bytes = bytes
+    basestring = (str,bytes)
+else:
+    # 'unicode' exists, must be Python 2
+    str = str
+    unicode = unicode
+    bytes = str
+    basestring = basestring
 
 class Base64ImageField(ImageField):
     """


### PR DESCRIPTION
This commit fixes a [bug](https://github.com/leriomaggio/drf-extra-fields/blob/master/drf_extra_fields/fields.py#L35)
that caused a `NameError` exception to be raised in Python3.

This was due to the fact that the `basestring` abstract type has been [removed](https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit) in Py3k.