### PR TITLE
Base64ImageField: do not override to_representation

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -49,10 +49,6 @@ class Base64ImageField(ImageField):
             return super(Base64ImageField, self).to_internal_value(data)
         raise ValidationError(_('This is not an base64 string'))
 
-    def to_representation(self, value):
-        # Return url including domain name.
-        return value.name
-
     def get_file_extension(self, filename, decoded_file):
         extension = imghdr.what(filename, decoded_file)
         extension = "jpg" if extension == "jpeg" else extension


### PR DESCRIPTION
By not overwriting it, the standard behaviour of `use_url` /
`UPLOADED_FILES_USE_URL` will be kept.  This will then also match the
behaviour described in the comment - where the URL is meant to be
returned instead of the name.