### PR TITLE
Optional Base64 Image downloads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Intherited by `ImageField`
  - It takes a base64 image as a string.
  - a base64 image:  `data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7`
  - Base64ImageField accepts only the part after base64, `R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7`
+ - It takes the optional parameter represent_in_base64(False by default), if set to True it wil allow for base64-encoded downloads of an ImageField.
  
 
 **Example:**

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -40,6 +40,11 @@ class Base64ImageField(ImageField):
     A django-rest-framework field for handling image-uploads through raw post data.
     It uses base64 for en-/decoding the contents of the file.
     """
+
+    def __init__(self, *args, **kwargs):
+        self.represent_in_base64 = kwargs.pop('represent_in_base64', False)
+        super(Base64ImageField, self).__init__(*args, **kwargs)
+
     def to_internal_value(self, base64_data):
         # Check if this is a base64 string
         if base64_data in EMPTY_VALUES:
@@ -66,6 +71,16 @@ class Base64ImageField(ImageField):
         extension = imghdr.what(filename, decoded_file)
         extension = "jpg" if extension == "jpeg" else extension
         return extension
+
+    def to_representation(self, image):
+        if self.represent_in_base64:
+            try:
+                with open(image.path, 'rb') as f:
+                    return base64.b64encode(f.read()).decode()
+            except StandardError as err:
+                raise IOError("Error encoding image file")
+        else:
+            return super(ImageField, self).to_representation(image)
 
 
 class RangeField(DictField):


### PR DESCRIPTION
The Base64ImageField will now allow the optional behaviour of serialising modelImage fields into base64. This will only work if represent_in_base64 is explicitly set to True, otherwise the default behaviour will remain.