### PR TITLE
strip base64 header if it's present

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Intherited by `ImageField`
 
  - It takes a base64 image as a string.
  - a base64 image:  `data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7`
- - Base64ImageField accepts only the part after base64, `R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7`
+ - Base64ImageField accepts the entire string or just the part after base64, `R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7`
  - It takes the optional parameter represent_in_base64(False by default), if set to True it wil allow for base64-encoded downloads of an ImageField.
  
 

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -51,6 +51,10 @@ class Base64ImageField(ImageField):
             return None
 
         if isinstance(base64_data, six.string_types):
+            # Strip base64 header.
+            if ';base64,' in base64_data:
+                header, base64_data = base64_data.split(';base64,')
+
             # Try to decode the file. Return validation error if it fails.
             try:
                 decoded_file = base64.b64decode(base64_data)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -67,6 +67,18 @@ class Base64ImageSerializerTests(TestCase):
         self.assertEqual(serializer.validated_data['created'], uploaded_image.created)
         self.assertFalse(serializer.validated_data is uploaded_image)
 
+    def test_create_with_base64_prefix(self):
+        """
+        Test for creating Base64 image in the server side
+        """
+        now = datetime.datetime.now()
+        file = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
+        serializer = UploadedBase64ImageSerializer(data={'created': now, 'file': file})
+        uploaded_image = UploadedBase64Image(file=file, created=now)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data['created'], uploaded_image.created)
+        self.assertFalse(serializer.validated_data is uploaded_image)
+
     def test_validation_error_with_non_file(self):
         """
         Passing non-base64 should raise a validation error.


### PR DESCRIPTION
The motivation for this PR is that it makes it easier for API clients to use.