### PR TITLE
Fix for Python 3 (removed StandardError)

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -81,7 +81,7 @@ class Base64ImageField(ImageField):
             try:
                 with open(image.path, 'rb') as f:
                     return base64.b64encode(f.read()).decode()
-            except StandardError as err:
+            except Exception:
                 raise IOError("Error encoding image file")
         else:
             return super(ImageField, self).to_representation(image)


### PR DESCRIPTION
Small change to prevent an exception being thrown for missing StandardError under Python 3