### PR TITLE
Add python 3 trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],


### PR DESCRIPTION
The python 3 classifier is required to list the package in the "Python 3" list on PyPI.

Also this tool: https://github.com/brettcannon/caniusepython3 uses the classifier to check for python 3 support for a package