### PR TITLE
Fixing PresentablePrimaryKeyRelatedField to show in html view

### DIFF
--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from rest_framework.relations import PrimaryKeyRelatedField
 
 
@@ -23,6 +24,19 @@ class PresentablePrimaryKeyRelatedField(PrimaryKeyRelatedField):
             'PresentablePrimaryKeyRelatedField must provide a `presentation_serializer` argument'
         )
         super(PresentablePrimaryKeyRelatedField, self).__init__(**kwargs)
+
+    def get_choices(self, cutoff=None):
+        queryset = self.get_queryset()
+        if queryset is None:
+            # Ensure that field.choices returns something sensible
+            # even when accessed with a read-only field.
+            return {}
+
+        if cutoff is not None:
+            queryset = queryset[:cutoff]
+
+        return OrderedDict([(item.pk, self.display_value(item))
+                            for item in queryset])
 
     def to_representation(self, data):
         return self.presentation_serializer(data, context=self.context).data


### PR DESCRIPTION
In html view of DRF, ``get_choices()`` is called to get the choices.
As we have override ``to_representation()`` and it returns a ``dictionary`` instead of ``pk``, the html view raise errors.
So override the ``get_choices()`` function in order to return the ``pk`` value list