### PR TITLE
Added fallback support to Base64ImageField for regular ImageType/multipart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .idea
 .pypirc
 .tox/
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
-
-env:
-    - TESTENV=py27
-    - TESTENV=py34
-
+python:
+  - "2.7"
+  - "3.4"
+  - "3.6"
 install:
-    - pip install tox
+    - pip install tox-travis
+    - sudo apt-get install gdal-bin
 
 script:
-    - tox -e $TESTENV
+    - tox
 
 notifications:
     email: false

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -99,6 +99,24 @@ class Base64ImageField(Base64FieldMixin, ImageField):
         return extension
 
 
+class HybridImageField(Base64ImageField):
+    """
+    A django-rest-framework field for handling image-uploads through
+    raw post data, with a fallback to multipart form data.
+    """
+
+    def to_internal_value(self, data):
+        """
+        Try Base64Field first, and then try the FileField
+        ``to_internal_value``, MRO doesn't work here because
+        Base64FieldMixin throws before ImageField can run.
+        """
+        try:
+            return Base64FieldMixin.to_internal_value(self, data)
+        except ValidationError:
+            return ImageField.to_internal_value(self, data)
+
+
 class Base64FileField(Base64FieldMixin, FileField):
     """
     A django-rest-framework field for handling file-uploads through raw post data.
@@ -110,6 +128,24 @@ class Base64FileField(Base64FieldMixin, FileField):
 
     def get_file_extension(self, filename, decoded_file):
         raise NotImplemented('Implement file validation and return matching extension.')
+
+
+class HybridFileField(Base64FileField):
+    """
+    A django-rest-framework field for handling file-uploads through
+    raw post data, with a fallback to multipart form data.
+    """
+
+    def to_internal_value(self, data):
+        """
+        Try ImageField first, and then try the Base64FieldMixin
+        ``to_internal_value``, MRO doesn't work here because
+        Base64FieldMixin throws before FileField can run.
+        """
+        try:
+            return Base64FieldMixin.to_internal_value(self, data)
+        except ValidationError:
+            return FileField.to_internal_value(self, data)
 
 
 class RangeField(DictField):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py34,py36
 
 [testenv]
 deps =
@@ -8,4 +8,5 @@ deps =
     Pillow
     pytest-django
     psycopg2
-commands = py.test
+    mock
+commands = py.test {posargs}


### PR DESCRIPTION
I found it handy to support a fallback of using the base DRF Image to_internal_value to handle form uploads in addition to Base64 encoded JSON, so I made hyrbrid versions