### PR TITLE
Float output for PointField

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Point field for GeoDjango
      "latitude": 49.8782482189424,
      "longitude": 24.452545489
     }
+ - It takes the optional parameter `str_points` (False by default), if set to True it serializes the longitude/latitude
+ values as strings
     
 **Example:**
 

--- a/drf_extra_fields/geo_fields.py
+++ b/drf_extra_fields/geo_fields.py
@@ -1,7 +1,6 @@
 import json
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos.error import GEOSException
-from django.utils.encoding import smart_str
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
@@ -62,7 +61,7 @@ class PointField(serializers.Field):
 
         if isinstance(value, GEOSGeometry):
             value = {
-                "latitude": smart_str(value.y),
-                "longitude": smart_str(value.x)
+                "latitude": value.y,
+                "longitude": value.x
             }
         return value

--- a/drf_extra_fields/geo_fields.py
+++ b/drf_extra_fields/geo_fields.py
@@ -1,6 +1,7 @@
 import json
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos.error import GEOSException
+from django.utils.encoding import smart_str
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
@@ -25,6 +26,10 @@ class PointField(serializers.Field):
     default_error_messages = {
         'invalid': _('Enter a valid location.'),
     }
+
+    def __init__(self, *args, **kwargs):
+        self.str_points = kwargs.pop('str_points', False)
+        super(PointField, self).__init__(*args, **kwargs)
 
     def to_internal_value(self, value):
         """
@@ -64,4 +69,9 @@ class PointField(serializers.Field):
                 "latitude": value.y,
                 "longitude": value.x
             }
+
+        if self.str_points:
+            value['longitude'] = smart_str(value.pop('longitude'))
+            value['latitude'] = smart_str(value.pop('latitude'))
+
         return value

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -306,6 +306,17 @@ class PointSerializerTest(TestCase):
         serializer = PointSerializer(data={'created': now, 'point': point})
         self.assertFalse(serializer.is_valid())
 
+    def test_json_representation(self):
+        now = datetime.datetime.now()
+        point = {
+            "latitude": 49.8782482189424,
+            "longitude": 24.452545489
+        }
+        saved_point = SavePoint(point=point, created=now)
+        serializer = PointSerializer(saved_point)
+        self.assertTrue(isinstance(serializer.data['point']['latitude'], float))
+        self.assertTrue(isinstance(serializer.data['point']['longitude'], float))
+
 
 # Backported from django_rest_framework/tests/test_fields.py
 def get_items(mapping_or_list_of_two_tuples):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -248,6 +248,10 @@ class PointSerializer(serializers.Serializer):
         return SavePoint(**validated_data)
 
 
+class StringPointSerializer(PointSerializer):
+    point = PointField(required=False, str_points=True)
+
+
 class PointSerializerTest(TestCase):
 
     def test_create(self):
@@ -306,16 +310,29 @@ class PointSerializerTest(TestCase):
         serializer = PointSerializer(data={'created': now, 'point': point})
         self.assertFalse(serializer.is_valid())
 
-    def test_json_representation(self):
+    def test_serialization(self):
+        """
+        Regular JSON serialization should output float values
+        """
+        from django.contrib.gis.geos import Point
         now = datetime.datetime.now()
-        point = {
-            "latitude": 49.8782482189424,
-            "longitude": 24.452545489
-        }
+        point = Point(24.452545489, 49.8782482189424)
         saved_point = SavePoint(point=point, created=now)
         serializer = PointSerializer(saved_point)
-        self.assertTrue(isinstance(serializer.data['point']['latitude'], float))
-        self.assertTrue(isinstance(serializer.data['point']['longitude'], float))
+        self.assertEqual(serializer.data['point'], {'latitude': 49.8782482189424, 'longitude': 24.452545489})
+
+    def test_str_points_serialization(self):
+        """
+        PointField with str_points=True should output string values
+        """
+        from django.contrib.gis.geos import Point
+        now = datetime.datetime.now()
+        # test input is shortened due to string conversion rounding
+        # gps has at max 8 decimals, so it doesn't make a difference
+        point = Point(24.452545489, 49.8782482189)
+        saved_point = SavePoint(point=point, created=now)
+        serializer = StringPointSerializer(saved_point)
+        self.assertEqual(serializer.data['point'], {'latitude': '49.8782482189', 'longitude': '24.452545489'})
 
 
 # Backported from django_rest_framework/tests/test_fields.py


### PR DESCRIPTION
This pull request contains the changes necessary in order for the values of the `PointField` to be serialized as `float` when serializing to json.

Existing Issue: https://github.com/Hipo/drf-extra-fields/issues/38