### PR TITLE
Handle ValueError in Base64ImageField

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -52,7 +52,7 @@ class Base64FieldMixin(object):
             # Try to decode the file. Return validation error if it fails.
             try:
                 decoded_file = base64.b64decode(base64_data)
-            except (TypeError, binascii.Error):
+            except (TypeError, binascii.Error, ValueError):
                 raise ValidationError(self.INVALID_FILE_MESSAGE)
             # Generate file name:
             file_name = str(uuid.uuid4())[:12]  # 12 characters are more than enough.


### PR DESCRIPTION
Some malformed client sent some garbage input which resulted in this error. Base64ImageField should handle this gracefully. The base64.py raises a UnicodeEncodeError, which then throws a ValueError which `drf-extra-fields` should handle (https://github.com/python/cpython/blob/master/Lib/base64.py#L39).

Here's the full stack trace.
```
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.6/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/app/.heroku/python/lib/python3.6/contextlib.py", line 53, in inner
    return func(*args, **kwds)
  File "/app/.heroku/python/lib/python3.6/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper
    return wrapped(*args, **kwargs)
  File "/app/.heroku/python/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/viewsets.py", line 95, in view
    return self.dispatch(request, *args, **kwargs)
  File "/app/.heroku/python/lib/python3.6/site-packages/newrelic/hooks/component_djangorestframework.py", line 46, in _nr_wrapper_APIView_dispatch_
    return wrapped(*args, **kwargs)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/views.py", line 494, in dispatch
    response = self.handle_exception(exc)
  File "/app/.heroku/python/lib/python3.6/site-packages/newrelic/hooks/component_djangorestframework.py", line 53, in _handle_exception_wrapper
    return wrapped(*args, **kwargs)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/views.py", line 454, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/views.py", line 491, in dispatch
    response = handler(request, *args, **kwargs)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/mixins.py", line 20, in create
    serializer.is_valid(raise_exception=True)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/serializers.py", line 236, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/serializers.py", line 435, in run_validation
    value = self.to_internal_value(data)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/serializers.py", line 465, in to_internal_value
    validated_value = field.run_validation(primitive_value)
  File "/app/.heroku/python/lib/python3.6/site-packages/rest_framework/fields.py", line 523, in run_validation
    value = self.to_internal_value(data)
  File "/app/.heroku/src/django-extra-fields/drf_extra_fields/fields.py", line 115, in to_internal_value
    return Base64FieldMixin.to_internal_value(self, data)
  File "/app/.heroku/src/django-extra-fields/drf_extra_fields/fields.py", line 54, in to_internal_value
    decoded_file = base64.b64decode(base64_data)
  File "/app/.heroku/python/lib/python3.6/base64.py", line 80, in b64decode
    s = _bytes_from_decode_data(s)
  File "/app/.heroku/python/lib/python3.6/base64.py", line 39, in _bytes_from_decode_data
    raise ValueError('string argument should contain only ASCII characters')
ValueError: string argument should contain only ASCII charactersTraceback (most recent call last):
  File "/app/.heroku/python/lib/python3.6/base64.py", line 37, in _bytes_from_decode_data
    return s.encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)
```