### PR TITLE
Support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
+
+dist: xenial
+
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+
 install:
     - pip install tox-travis
     - sudo apt-get install gdal-bin


### PR DESCRIPTION
`dist: xenial` is needed for Python 3.7: https://github.com/travis-ci/travis-ci/issues/9815