### PR TITLE
Fix manager to queryset in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 class PostSerializer(serializers.ModelSerializer):
     user = PresentablePrimaryKeyRelatedField(
-        queryset=User.objects,
+        queryset=User.objects.all(),
         presentation_serializer=UserSerializer
     )
     class Meta:


### PR DESCRIPTION
I fixed the mistakenly given argument `User.objects` (a manager) to `User.objects.all()` (a queryset).