### PR TITLE
Improve error message when base64 data is an invalid type

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -72,7 +72,8 @@ class Base64FieldMixin(object):
             complete_file_name = file_name + "." + file_extension
             data = ContentFile(decoded_file, name=complete_file_name)
             return super(Base64FieldMixin, self).to_internal_value(data)
-        raise ValidationError(_('This is not an base64 string'))
+        raise ValidationError(_('Invalid type. This is not an base64 string: {}'.format(
+            type(base64_data))))
 
     def get_file_extension(self, filename, decoded_file):
         raise NotImplementedError


### PR DESCRIPTION
When this error is returned, it is not very clear about the fact that error is actually a type error (the fact that the input is not a `str`). The current error seems to imply that the value is not "base64 encoded" correctly.