### PR TITLE
Replaced buggy imghdr with PIL

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -1,3 +1,4 @@
+import imghdr
 import io
 import base64
 import binascii
@@ -105,8 +106,14 @@ class Base64ImageField(Base64FieldMixin, ImageField):
     INVALID_TYPE_MESSAGE = _("The type of the image couldn't be determined.")
 
     def get_file_extension(self, filename, decoded_file):
-        image = Image.open(io.BytesIO(decoded_file))
-        extension = image.format.lower()
+        extension = imghdr.what(filename, decoded_file)
+
+        # Try with PIL as fallback if format not detected due
+        # to bug in imghdr https://bugs.python.org/issue16512
+        if extension is None:
+            image = Image.open(io.BytesIO(decoded_file))
+            extension = image.format.lower()
+
         extension = "jpg" if extension == "jpeg" else extension
         return extension
 

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -1,7 +1,9 @@
+import io
 import base64
 import binascii
-import imghdr
 import uuid
+
+from PIL import Image
 
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
@@ -103,7 +105,8 @@ class Base64ImageField(Base64FieldMixin, ImageField):
     INVALID_TYPE_MESSAGE = _("The type of the image couldn't be determined.")
 
     def get_file_extension(self, filename, decoded_file):
-        extension = imghdr.what(filename, decoded_file)
+        image = Image.open(io.BytesIO(decoded_file))
+        extension = image.format.lower()
         extension = "jpg" if extension == "jpeg" else extension
         return extension
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,6 @@
 import datetime
 import base64
+import imghdr
 import os
 
 import django
@@ -134,11 +135,15 @@ class Base64ImageSerializerTests(TestCase):
         """
         now = datetime.datetime.now()
         file = UNDETECTABLE_BY_IMGHDR_SAMPLE
+
+        # check image is undetectable by imghdr
+        self.assertIsNone(imghdr.what('test.jpeg', base64.b64decode(file)))
+
         uploaded_image = UploadedBase64Image(file=file, created=now)
-        serializer = UploadedBase64ImageSerializer(instance=uploaded_image, data={'created': now, 'file': ''})
+        serializer = UploadedBase64ImageSerializer(instance=uploaded_image, data={'created': now, 'file': file})
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.validated_data['created'], uploaded_image.created)
-        self.assertIsNone(serializer.validated_data['file'])
+        self.assertIsNotNone(serializer.validated_data['file'])
 
     def test_download(self):
         encoded_source = 'R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='


### PR DESCRIPTION
There is a [bug](https://bugs.python.org/issue16512) in python's imghdr module. It does not recognize some valid `jpeg` files like [this](https://picsum.photos/500/500/?image=705). drf-extra-fields is using this module to check file types which fails for some images. I have replaced type checking functionality with PIL. 