### PR TITLE
changes return type of Base64FieldMixin to SimpleUploadedFile

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework >= 3.0.1
 pillow
 flake8
 mock
+pytest-django

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ from setuptools import setup
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
 
+with open(os.path.join(os.path.dirname(__file__), 'requirements.txt')) as requirements_txt:
+    requirements = requirements_txt.read().strip().splitlines()
+
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
@@ -20,6 +23,7 @@ setup(
     author_email='pypi@hipolabs.com',
     url='https://github.com/Hipo/drf-extra-fields',
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    install_requires=requirements,
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
This PR has 2 changes:
i. I replaced to Base64FieldMixin.to_internal_value to SimpleUploadedFile from ContentFile.  
ii. Added pytest-django to requirements and included requirements.txt in setup.py

i.  I replaced to Base64FieldMixin.to_internal_value to SimpleUploadedFile from ContentFile. 

When you upload a file, Django sets the content_type and on models you receive an InMemoryUploadedFile so that you can do this very easily

```python
class SomeModel(models.Model):
   uploaded_file = models.FileField(upload_to=settings.ASSET_UPLOAD_DIR)
   ...
    def save(self, *args, **kwargs):
        # self.uploaded_file is InMemoryUploadedFile
        self.content_type = self.uploaded_file.file.content_type
```

With a proper base64 encoded file, client already provides the content_type
```
data:image/png;base64,aGVsbG8gd29ybGQK....
```

When using a ContentFile you just loose that content_type. I simply replaced ContentFile with a SimpleUploadedFile - which wraps InMemoryUploadedFile anyways. So on models you get the same behaviour as you upload a file with multipart/form-data.

ii. On setup.py I added install_requires, because when someone installs the package with "python setup.py develop" etc. it should install the dependencies. Also pytest-django was missing from the requirements.txt - which was needed to run the tests. 

Let me know your thoughts
