### PR TITLE
Pass in arbitrary arguments to PresentationSerializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,16 @@ class UserSerializer(serializers.ModelSerializer):
 class PostSerializer(serializers.ModelSerializer):
     user = PresentablePrimaryKeyRelatedField(
         queryset=User.objects.all(),
-        presentation_serializer=UserSerializer
+        presentation_serializer=UserSerializer,
+        presentation_serializer_kwargs={
+            'example': [
+                'of', 
+                'passing', 
+                'kwargs', 
+                'to', 
+                'serializer',
+            ]
+        }
     )
     class Meta:
         model = Post

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -20,6 +20,7 @@ class PresentablePrimaryKeyRelatedField(PrimaryKeyRelatedField):
 
     def __init__(self, **kwargs):
         self.presentation_serializer = kwargs.pop('presentation_serializer', None)
+        self.presentation_serializer_kwargs = kwargs.pop('presentation_serializer_kwargs', dict())
         assert self.presentation_serializer is not None, (
             'PresentablePrimaryKeyRelatedField must provide a `presentation_serializer` argument'
         )
@@ -39,4 +40,4 @@ class PresentablePrimaryKeyRelatedField(PrimaryKeyRelatedField):
                             for item in queryset])
 
     def to_representation(self, data):
-        return self.presentation_serializer(data, context=self.context).data
+        return self.presentation_serializer(data, context=self.context, **self.presentation_serializer_kwargs).data


### PR DESCRIPTION
I have numerous additional extensions to my serializers and need the ability to pass in arbitrary keyword arguments to limit the fields returned, etc.