### PR TITLE
Increase random file name length by 1 to avoid adblocker trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 .pypirc
 .tox/
 .cache/
+venv/
+.vscode/

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -80,9 +80,9 @@ class Base64FieldMixin(object):
         raise NotImplementedError
 
     def get_file_name(self, decoded_file):
+        # 12 Characters can result in filenames that trigger ablockers. (https://stackoverflow.com/questions/57227131)
         return str(uuid.uuid4())[:13]  # 13 characters are more than enough. 
-        # 12 Characters can result in filenames that trigger ablockers.
-        # See https://stackoverflow.com/questions/57227131/images-that-fit-the-regexp-ad0-9-png-can-not-be-loaded-in-any-browser
+
 
     def to_representation(self, file):
         if self.represent_in_base64:

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -80,7 +80,7 @@ class Base64FieldMixin(object):
         raise NotImplementedError
 
     def get_file_name(self, decoded_file):
-        return str(uuid.uuid4())[:12]  # 12 characters are more than enough.
+        return str(uuid.uuid4())[:14]  # 14 characters are more than enough. 12 Characters can trigger ablockers.
 
     def to_representation(self, file):
         if self.represent_in_base64:

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -80,7 +80,9 @@ class Base64FieldMixin(object):
         raise NotImplementedError
 
     def get_file_name(self, decoded_file):
-        return str(uuid.uuid4())[:13]  # 13 characters are more than enough. 12 Characters can trigger ablockers.
+        return str(uuid.uuid4())[:13]  # 13 characters are more than enough. 
+        # 12 Characters can result in filenames that trigger ablockers.
+        # See https://stackoverflow.com/questions/57227131/images-that-fit-the-regexp-ad0-9-png-can-not-be-loaded-in-any-browser
 
     def to_representation(self, file):
         if self.represent_in_base64:

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -83,7 +83,7 @@ class Base64FieldMixin(object):
         # 12 Characters can result in filenames that trigger ablockers because
         # they can end with '-ad0[.png]', which is blocked by adblockers
         # See https://stackoverflow.com/questions/57227131
-        return str(uuid.uuid4())[:13]  # 13 characters are more than enough. 
+        return str(uuid.uuid4())[:13]  # 13 characters are more than enough.
 
     def to_representation(self, file):
         if self.represent_in_base64:

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -80,7 +80,8 @@ class Base64FieldMixin(object):
         raise NotImplementedError
 
     def get_file_name(self, decoded_file):
-        # 12 Characters can result in filenames that trigger ablockers. (https://stackoverflow.com/questions/57227131)
+        # 12 Characters can result in filenames that trigger ablockers. 
+        # See https://stackoverflow.com/questions/57227131
         return str(uuid.uuid4())[:13]  # 13 characters are more than enough. 
 
 

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -80,7 +80,7 @@ class Base64FieldMixin(object):
         raise NotImplementedError
 
     def get_file_name(self, decoded_file):
-        return str(uuid.uuid4())[:14]  # 14 characters are more than enough. 12 Characters can trigger ablockers.
+        return str(uuid.uuid4())[:13]  # 13 characters are more than enough. 12 Characters can trigger ablockers.
 
     def to_representation(self, file):
         if self.represent_in_base64:

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -80,10 +80,10 @@ class Base64FieldMixin(object):
         raise NotImplementedError
 
     def get_file_name(self, decoded_file):
-        # 12 Characters can result in filenames that trigger ablockers. 
+        # 12 Characters can result in filenames that trigger ablockers because
+        # they can end with '-ad0[.png]', which is blocked by adblockers
         # See https://stackoverflow.com/questions/57227131
         return str(uuid.uuid4())[:13]  # 13 characters are more than enough. 
-
 
     def to_representation(self, file):
         if self.represent_in_base64:


### PR DESCRIPTION
Random names generated by drf-extra-fields include file names that end with -ad0, which is blocked by ublock origin and possibly other adblockers. 

See https://github.com/Hipo/drf-extra-fields/issues/94 and the [StackOverflow issue by me](https://stackoverflow.com/questions/57227131/images-that-fit-the-regexp-ad0-9-png-can-not-be-loaded-in-any-browser/57227395#57227395).