### PR TITLE
Use full uuid4 in Base64FieldMixin.get_file_name()

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -80,10 +80,7 @@ class Base64FieldMixin(object):
         raise NotImplementedError
 
     def get_file_name(self, decoded_file):
-        # 12 Characters can result in filenames that trigger ablockers because
-        # they can end with '-ad0[.png]', which is blocked by adblockers
-        # See https://stackoverflow.com/questions/57227131
-        return str(uuid.uuid4())[:13]  # 13 characters are more than enough.
+        return str(uuid.uuid4())
 
     def to_representation(self, file):
         if self.represent_in_base64:


### PR DESCRIPTION
There is no real benefit in keeping it short.