### PR TITLE
Add PyPy3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - python: 3.7
       env: TOXENV=py37
     - env: TOXENV=flake8
+    - python: pypy3
+      env: TOXENV=pypy3
 
 install:
   - pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],


### PR DESCRIPTION
We have witnessed PyPy3 speeding up DRF significantly. This PR adds testing for PyPy3 so that support does not regress and users are able to continue to take advantage of a very performant alternative to CPython.