### PR TITLE
Handle invalid Base64 inputs in Base64ImageField

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -124,7 +124,11 @@ class Base64ImageField(Base64FieldMixin, ImageField):
         # Try with PIL as fallback if format not detected due
         # to bug in imghdr https://bugs.python.org/issue16512
         if extension is None:
-            image = Image.open(io.BytesIO(decoded_file))
+            try:
+                image = Image.open(io.BytesIO(decoded_file))
+            except (OSError, IOError):
+                raise ValidationError(self.INVALID_FILE_MESSAGE)
+
             extension = image.format.lower()
 
         extension = "jpg" if extension == "jpeg" else extension

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-extra-fields',
-    version='2.0.0',
+    version='2.0.1',
     packages=['drf_extra_fields',
               'drf_extra_fields.runtests'],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-extra-fields',
-    version='2.0.2',
+    version='2.0.3',
     packages=['drf_extra_fields',
               'drf_extra_fields.runtests'],
     include_package_data=True,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -105,6 +105,18 @@ class Base64ImageSerializerTests(TestCase):
         self.assertEqual(serializer.validated_data['created'], uploaded_image.created)
         self.assertFalse(serializer.validated_data is uploaded_image)
 
+    def test_create_with_invalid_base64(self):
+        """
+        Test for creating Base64 image with an invalid Base64 string in the server side
+        """
+        now = datetime.datetime.now()
+        file = 'this_is_not_a_base64'
+        errmsg = "Please upload a valid image."
+        serializer = UploadedBase64ImageSerializer(data={'created': now, 'file': file})
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors, {'file': [errmsg]})
+
     def test_validation_error_with_non_file(self):
         """
         Passing non-base64 should raise a validation error.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -111,22 +111,20 @@ class Base64ImageSerializerTests(TestCase):
         """
         now = datetime.datetime.now()
         file = 'this_is_not_a_base64'
-        errmsg = "Please upload a valid image."
         serializer = UploadedBase64ImageSerializer(data={'created': now, 'file': file})
 
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'file': [errmsg]})
+        self.assertEqual(serializer.errors, {'file': [Base64ImageField.INVALID_FILE_MESSAGE]})
 
     def test_validation_error_with_non_file(self):
         """
         Passing non-base64 should raise a validation error.
         """
         now = datetime.datetime.now()
-        errmsg = "Please upload a valid image."
         serializer = UploadedBase64ImageSerializer(data={'created': now,
                                                          'file': 'abc'})
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'file': [errmsg]})
+        self.assertEqual(serializer.errors, {'file': [Base64ImageField.INVALID_FILE_MESSAGE]})
 
     def test_remove_with_empty_string(self):
         """
@@ -238,10 +236,9 @@ class Base64FileSerializerTests(TestCase):
         Passing non-base64 should raise a validation error.
         """
         now = datetime.datetime.now()
-        errmsg = "Please upload a valid file."
         serializer = UploadedBase64FileSerializer(data={'created': now, 'file': 'abc'})
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'file': [errmsg]})
+        self.assertEqual(serializer.errors, {'file': [Base64FileField.INVALID_FILE_MESSAGE]})
 
     def test_remove_with_empty_string(self):
         """


### PR DESCRIPTION
Issue: https://github.com/Hipo/drf-extra-fields/issues/109

The exception catches both `OSError` and `IOError` because `Python3` raises and `OSError` and `Python2` raises an `IOError`.

- Invalid Base64 image inputs are handled.
- Test for invalid Base64 image inputs are implemented.
- Error messages in tests are now being taken from related Field classes.
- Version is bumped from `2.0.0` to `2.0.1`