### PR TITLE
support Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: xenial
+dist: bionic
 
 matrix:
   include:
@@ -12,6 +12,8 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
     - env: TOXENV=flake8
 
 install:

--- a/drf_extra_fields/compat.py
+++ b/drf_extra_fields/compat.py
@@ -4,3 +4,10 @@ try:
     from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange
 except ImportError:
     postgres_fields = DateRange = DateTimeTZRange = NumericRange = None
+
+# django.utils.six has been removed in Django 3.0
+try:
+    from django.utils.six import string_types, text_type
+except ImportError:
+    string_types = str
+    text_type = str

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -6,7 +6,6 @@ import uuid
 
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework.fields import (
@@ -25,6 +24,8 @@ from .compat import (
     DateTimeTZRange,
     NumericRange,
     postgres_fields,
+    string_types,
+    text_type,
 )
 
 
@@ -55,7 +56,7 @@ class Base64FieldMixin(object):
         if base64_data in self.EMPTY_VALUES:
             return None
 
-        if isinstance(base64_data, six.string_types):
+        if isinstance(base64_data, string_types):
             # Strip base64 header.
             if ';base64,' in base64_data:
                 header, base64_data = base64_data.split(';base64,')
@@ -196,7 +197,7 @@ class RangeField(DictField):
             except KeyError:
                 continue
 
-            validated_dict[six.text_type(key)] = self.child.run_validation(value)
+            validated_dict[text_type(key)] = self.child.run_validation(value)
 
         for key in ('bounds', 'empty'):
             try:
@@ -204,7 +205,7 @@ class RangeField(DictField):
             except KeyError:
                 continue
 
-            validated_dict[six.text_type(key)] = value
+            validated_dict[text_type(key)] = value
 
         return self.range_type(**validated_dict)
 

--- a/drf_extra_fields/geo_fields.py
+++ b/drf_extra_fields/geo_fields.py
@@ -2,10 +2,10 @@ import json
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos.error import GEOSException
 from django.utils.encoding import smart_str
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
+from .compat import string_types
 
 EMPTY_VALUES = (None, '', [], (), {})
 
@@ -38,7 +38,7 @@ class PointField(serializers.Field):
         if value in EMPTY_VALUES and not self.required:
             return None
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, string_types):
             try:
                 value = value.replace("'", '"')
                 value = json.loads(value)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py35,py36,py37
+envlist = flake8,py27,py35,py36,py37,py38
 
 [testenv]
 deps = -r requirements_dev.txt


### PR DESCRIPTION
Fix #115 by moving `text_type` and `string_types` imports in the `compat` module. 