### PR TITLE
Add LICENSE file metadata to packaged distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "Base64ImageField": ["Pillow == 6.2.1"],
     },
     license='Apache-2.0',
+    license_files=['LICENSE'],
     description='Additional fields for Django Rest Framework.',
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Currently [pip-licenses](https://github.com/raimon49/pip-licenses) can't include the LICENSE file for this project because the correct metadata is not setup.

This PR sets up the metadata correctly so the LICENSE file is properly included/linked to in source and wheel distributions.