### PR TITLE
Stop using deprecated ugettext alias

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -6,7 +6,7 @@ import uuid
 
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.fields import (
     DateField,

--- a/drf_extra_fields/geo_fields.py
+++ b/drf_extra_fields/geo_fields.py
@@ -2,7 +2,7 @@ import json
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos.error import GEOSException
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 from .compat import string_types


### PR DESCRIPTION
This alias is only needed for python2 support, and is deprecated as of
django 4.0
https://docs.djangoproject.com/en/3.0/releases/3.0/#id3

Django's last LTS with python2 compatibility ends its extended support
in April 2020.
https://www.djangoproject.com/download/