### PR TITLE
Allow install of new versions of Pillow

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 django
 djangorestframework>=3.0
-Pillow == 6.2.1
+Pillow >= 6.2.1
 pytest-django
 pytest-cov
 psycopg2-binary

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     install_requires=['Django >= 1.4', 'djangorestframework >= 3.0.1'],
     extras_require={
-        "Base64ImageField": ["Pillow == 6.2.1"],
+        "Base64ImageField": ["Pillow >= 6.2.1"],
     },
     license='Apache-2.0',
     license_files=['LICENSE'],


### PR DESCRIPTION
Closes #126 

[Pillow 6.2.1 is 6 months old](https://pypi.org/project/Pillow/6.2.1/).

Users can still pin `Pillow` if they wish, using `requirements.txt`, `pip-tools`, `poetry`, `pipenv`, etc.