### PR TITLE
Add SRID attribute to PointField.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Point field for GeoDjango
     }
  - It takes the optional parameter `str_points` (False by default), if set to True it serializes the longitude/latitude
  values as strings
-    
+ - It takes the optional parameter `srid` (None by default), if set the Point created object will have its srid attribute set to the same value.
+
 **Example:**
 
 ```python

--- a/drf_extra_fields/geo_fields.py
+++ b/drf_extra_fields/geo_fields.py
@@ -29,6 +29,7 @@ class PointField(serializers.Field):
 
     def __init__(self, *args, **kwargs):
         self.str_points = kwargs.pop('str_points', False)
+        self.srid = kwargs.pop('srid', None)
         super(PointField, self).__init__(*args, **kwargs)
 
     def to_internal_value(self, value):
@@ -51,7 +52,8 @@ class PointField(serializers.Field):
                 longitude = value.get("longitude")
                 return GEOSGeometry('POINT(%(longitude)s %(latitude)s)' % {
                     "longitude": longitude,
-                    "latitude": latitude}
+                    "latitude": latitude},
+                                    srid=self.srid
                 )
             except (GEOSException, ValueError):
                 self.fail('invalid')

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -290,6 +290,10 @@ class StringPointSerializer(PointSerializer):
     point = PointField(required=False, str_points=True)
 
 
+class SridPointSerializer(PointSerializer):
+    point = PointField(required=False, srid=4326)
+
+
 class PointSerializerTest(TestCase):
 
     def test_create(self):
@@ -306,6 +310,7 @@ class PointSerializerTest(TestCase):
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.validated_data['created'], saved_point.created)
         self.assertFalse(serializer.validated_data is saved_point)
+        self.assertIsNone(serializer.validated_data['point'].srid)
 
     def test_validation_error_with_non_file(self):
         """
@@ -371,6 +376,19 @@ class PointSerializerTest(TestCase):
         saved_point = SavePoint(point=point, created=now)
         serializer = StringPointSerializer(saved_point)
         self.assertEqual(serializer.data['point'], {'latitude': '49.8782482189', 'longitude': '24.452545489'})
+
+    def test_srid_point(self):
+        """
+        PointField with srid should should result in a Point object with srid set
+        """
+        now = datetime.datetime.now()
+        point = {
+            "latitude": 49.8782482189424,
+            "longitude": 24.452545489
+        }
+        serializer = SridPointSerializer(data={'created': now, 'point': point})
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data['point'].srid, 4326)
 
 
 # Backported from django_rest_framework/tests/test_fields.py


### PR DESCRIPTION
Allow to set a SRID on the Point object created by the PointField serializer.

This is needed since Django requires SRID to be set since https://github.com/django/django/commit/bde86ce9ae17ee52aa5be9b74b64422f5219530d