### PR TITLE
Handle removed FloatRangeField import

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -11,6 +11,7 @@ from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange
 from rest_framework.fields import (
     DateField,
     DateTimeField,
+    DecimalField,
     DictField,
     EmailField,
     FileField,
@@ -223,8 +224,14 @@ class IntegerRangeField(RangeField):
     range_type = NumericRange
 
 
+# Deprecated - remove?
 class FloatRangeField(RangeField):
     child = FloatField()
+    range_type = NumericRange
+
+
+class DecimalRangeField(RangeField):
+    child = DecimalField(max_digits=5, decimal_places=2)
     range_type = NumericRange
 
 
@@ -243,7 +250,11 @@ class DateRangeField(RangeField):
 ModelSerializer.serializer_field_mapping[DateTimeRangeField] = DateTimeRangeField
 ModelSerializer.serializer_field_mapping[DateRangeField] = DateRangeField
 ModelSerializer.serializer_field_mapping[IntegerRangeField] = IntegerRangeField
-ModelSerializer.serializer_field_mapping[FloatRangeField] = FloatRangeField
+try:
+    compat_DecimalRangeField = DecimalRangeField
+except AttributeError:
+    compat_DecimalRangeField = FloatRangeField
+ModelSerializer.serializer_field_mapping[compat_DecimalRangeField] = DecimalRangeField
 
 
 class LowercaseEmailField(EmailField):


### PR DESCRIPTION
I'm not quite sure how you typically handle deprecations like these (how many old django versions to support, whether or not to provide a deprecation path for drf-extra-fields users or introduce an immediate breaking change), but I thought opening a PR as a starting point was better than an issue.

Also, I have to figure out how to solve the required parameters for the DecimalField, this was just to make it run at all.

For context, Django 2.2 introduced a new name for FloatRangeField:
https://docs.djangoproject.com/en/dev/releases/2.2/#id2
And in Django 3.1 they are removing the old name altogether:
https://docs.djangoproject.com/en/dev/releases/3.1/#features-removed-in-3-1