### PR TITLE
Add read_source parameter on PresentablePrimaryKeyField

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Extra Fields for Django Rest Framework
 
 Usage
 ================
- 
+
 Install the package
- 
+
 ```bash
 pip install django-extra-fields
 ```
 
-**Note:** 
+**Note:**
 - Install version 0.1 for Django Rest Framework 2.*
 - Install version 0.3 or greater for Django Rest Framework 3.*
 
@@ -222,10 +222,10 @@ class PostSerializer(serializers.ModelSerializer):
         presentation_serializer=UserSerializer,
         presentation_serializer_kwargs={
             'example': [
-                'of', 
-                'passing', 
-                'kwargs', 
-                'to', 
+                'of',
+                'passing',
+                'kwargs',
+                'to',
                 'serializer',
             ]
         }
@@ -292,10 +292,10 @@ class ProductSerializer(serializers.ModelSerializer):
         presentation_serializer=CategorySerializer,
         presentation_serializer_kwargs={
             'example': [
-                'of', 
-                'passing', 
-                'kwargs', 
-                'to', 
+                'of',
+                'passing',
+                'kwargs',
+                'to',
                 'serializer',
             ]
         }
@@ -340,6 +340,23 @@ class ProductSerializer(serializers.ModelSerializer):
 ```
 
 
+### read_source parameter
+You can also use read_source parameter on `PresentablePrimaryKeyRelatedField` and `PresentableSlugRelatedField`. With this parameter, you can specify the reading operation without any change in the write operation. For instance, if you want to soft delete an object or special sorting on the relation, you can use it. All the write operations will work normally (issue: [#136](https://github.com/Hipo/drf-extra-fields/issues/136)). Usage is the same as drf's [`source` parameter ](https://www.django-rest-framework.org/api-guide/fields/#source).
+
+```python
+class FooModel...:
+    ......
+    @property
+    def very_special_ordering_and_filtering(self):
+          return xxQueryset
+
+class FooSerializer:
+    field = PresentablePrimaryKeyRelatedField(......read_source="very_special_ordering_and_filtering"......)
+
+    class Meta:
+          model = fooModel
+```
+
 ## HybridImageField
 A django-rest-framework field for handling image-uploads through raw post data, with a fallback to multipart form data.
 
@@ -358,7 +375,7 @@ drf-yasg fix for BASE64 Fields:
 ----------------
 The [drf-yasg](https://github.com/axnsan12/drf-yasg) project seems to generate wrong documentation on Base64ImageField or Base64FileField. It marks those fields as readonly. Here is the workaround code for correct the generated document. (More detail on issue [#66](https://github.com/Hipo/drf-extra-fields/issues/66))
 
-```python 
+```python
 class PDFBase64FileField(Base64FileField):
     ALLOWED_TYPES = ['pdf']
 

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -7,7 +7,7 @@ from rest_framework.relations import (PrimaryKeyRelatedField, SlugRelatedField,
 
 class ReadSourceManyMixin(ManyRelatedField):
     def get_attribute(self, instance):
-        if self.child_relation.read_source:
+        if self.context['request'].method == "GET" and self.child_relation.read_source:
             self.source_attrs = [self.child_relation.read_source]
 
         return super().get_attribute(instance)

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -15,7 +15,7 @@ class CustomManyRelatedField(ManyRelatedField):
                 self.child_relation.read_source
             ).fget(instance)
 
-        return super().get_attribute(self, instance)
+        return super().get_attribute(instance)
 
 
 class PresentableRelatedFieldMixin(object):

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -8,7 +8,7 @@ from rest_framework.relations import (PrimaryKeyRelatedField, SlugRelatedField,
 class ReadSourceManyMixin(ManyRelatedField):
     def get_attribute(self, instance):
         if self.context['request'].method == "GET" and self.child_relation.read_source:
-            self.source_attrs = [self.child_relation.read_source]
+            self.source_attrs =  self.child_relation.read_source.split(".")
 
         return super().get_attribute(instance)
 
@@ -29,7 +29,7 @@ class ReadSourceMixin(object):
 
     def get_attribute(self, instance):
         if self.context['request'].method == "GET" and self.read_source:
-            self.source_attrs = [self.read_source]
+            self.source_attrs = self.read_source.split(".")
 
         return super().get_attribute(instance)
 

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -7,8 +7,8 @@ from rest_framework.relations import (PrimaryKeyRelatedField, SlugRelatedField,
 
 class ReadSourceManyMixin(ManyRelatedField):
     def get_attribute(self, instance):
-        if self.context['request'].method == "GET" and self.child_relation.read_source:
-            self.source_attrs =  self.child_relation.read_source.split(".")
+        if self.context['request'] and self.context['request'].method == "GET" and self.child_relation.read_source:
+            self.source_attrs = self.child_relation.read_source.split(".")
 
         return super().get_attribute(instance)
 
@@ -28,7 +28,7 @@ class ReadSourceMixin(object):
         return ReadSourceManyMixin(**list_kwargs)
 
     def get_attribute(self, instance):
-        if self.context['request'].method == "GET" and self.read_source:
+        if self.context['request'] and self.context['request'].method == "GET" and self.read_source:
             self.source_attrs = self.read_source.split(".")
 
         return super().get_attribute(instance)

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -1,10 +1,26 @@
 from collections import OrderedDict
 
-from rest_framework.relations import PrimaryKeyRelatedField, SlugRelatedField
+from rest_framework.relations import (PrimaryKeyRelatedField, SlugRelatedField,
+                                      MANY_RELATION_KWARGS, ManyRelatedField)
+
+
+class CustomManyRelatedField(ManyRelatedField):
+    def __init__(self, child_relation=None, *args, **kwargs):
+        super().__init__(child_relation, *args, **kwargs)
+
+    def get_attribute(self, instance):
+        if self.child_relation.read_source:
+            return getattr(
+                self.child_relation.presentation_serializer.Meta.model,
+                self.child_relation.read_source
+            ).fget(instance)
+
+        return super().get_attribute(self, instance)
 
 
 class PresentableRelatedFieldMixin(object):
     def __init__(self, **kwargs):
+        self.read_source = kwargs.pop("read_source", None)
         self.presentation_serializer = kwargs.pop("presentation_serializer", None)
         self.presentation_serializer_kwargs = kwargs.pop(
             "presentation_serializer_kwargs", dict()
@@ -25,6 +41,15 @@ class PresentableRelatedFieldMixin(object):
         - https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/relations.py#L132
         """
         return False
+
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        list_kwargs = {'child_relation': cls(*args, **kwargs)}
+        for key in kwargs:
+            if key in MANY_RELATION_KWARGS:
+                list_kwargs[key] = kwargs[key]
+
+        return CustomManyRelatedField(**list_kwargs)
 
     def get_choices(self, cutoff=None):
         queryset = self.get_queryset()

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -51,6 +51,14 @@ class PresentableRelatedFieldMixin(object):
 
         return CustomManyRelatedField(**list_kwargs)
 
+    def get_attribute(self, instance):
+        if self.read_source:
+            self.source_attrs.append("model")
+            self.source_attrs.append(self.read_source)
+            return super().get_attribute(instance).fget(instance)
+
+        return super().get_attribute(instance)
+
     def get_choices(self, cutoff=None):
         queryset = self.get_queryset()
         if queryset is None:

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -1,40 +1,52 @@
 from collections import OrderedDict
 
 
-from rest_framework.relations import (PrimaryKeyRelatedField, SlugRelatedField,
-                                      MANY_RELATION_KWARGS, ManyRelatedField)
-
-
-class ReadSourceManyMixin(ManyRelatedField):
-    def get_attribute(self, instance):
-        if self.context['request'] and self.context['request'].method == "GET" and self.child_relation.read_source:
-            self.source_attrs = self.child_relation.read_source.split(".")
-
-        return super().get_attribute(instance)
+from rest_framework.relations import (
+    PrimaryKeyRelatedField, SlugRelatedField, MANY_RELATION_KWARGS,
+    ManyRelatedField as DRFManyRelatedField
+)
 
 
 class ReadSourceMixin(object):
+    """
+    This mixin override get_attribute method and set read_source attribute
+    to source attribute if read_source attribute setted. For the purpose of
+    not want to effect of write operation, we don't override bind method.
+    """
+
+    class ManyRelatedField(DRFManyRelatedField):
+        def get_attribute(self, instance):
+            if self.child_relation.read_source:
+                self.source = self.child_relation.read_source
+                self.bind(self.field_name, self.parent)
+
+            return super().get_attribute(instance)
+
     def __init__(self, **kwargs):
         self.read_source = kwargs.pop("read_source", None)
         super().__init__(**kwargs)
 
     @classmethod
     def many_init(cls, *args, **kwargs):
+        if not kwargs.get("read_source", None):
+            return super().many_init(*args, **kwargs)
+
         list_kwargs = {'child_relation': cls(*args, **kwargs)}
         for key in kwargs:
             if key in MANY_RELATION_KWARGS:
                 list_kwargs[key] = kwargs[key]
 
-        return ReadSourceManyMixin(**list_kwargs)
+        return cls.ManyRelatedField(**list_kwargs)
 
     def get_attribute(self, instance):
-        if self.context['request'] and self.context['request'].method == "GET" and self.read_source:
-            self.source_attrs = self.read_source.split(".")
+        if self.read_source:
+            self.source = self.read_source
+            self.bind(self.field_name, self.parent)
 
         return super().get_attribute(instance)
 
 
-class PresentableRelatedFieldMixin(object):
+class PresentableRelatedFieldMixin(ReadSourceMixin):
     def __init__(self, **kwargs):
         self.presentation_serializer = kwargs.pop("presentation_serializer", None)
         self.presentation_serializer_kwargs = kwargs.pop(
@@ -47,6 +59,7 @@ class PresentableRelatedFieldMixin(object):
         super(PresentableRelatedFieldMixin, self).__init__(**kwargs)
 
     def use_pk_only_optimization(self):
+
         """
         Instead of sending pk only object, return full object. The object already retrieved from db by drf.
         This doesn't cause an extra query.
@@ -76,7 +89,7 @@ class PresentableRelatedFieldMixin(object):
 
 
 class PresentablePrimaryKeyRelatedField(
-        ReadSourceMixin, PresentableRelatedFieldMixin, PrimaryKeyRelatedField
+    PresentableRelatedFieldMixin, PrimaryKeyRelatedField
 ):
     """
     Override PrimaryKeyRelatedField to represent serializer data instead of a pk field of the object.

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -5,7 +5,7 @@ from drf_extra_fields.relations import (
     PresentablePrimaryKeyRelatedField,
     PresentableSlugRelatedField,
 )
-from .utils import MockObject, MockQueryset, MockRequest
+from .utils import MockObject, MockQueryset
 
 
 class PresentationSerializer(serializers.Serializer):
@@ -51,9 +51,7 @@ class TestPresentablePrimaryKeyRelatedField(APISimpleTestCase):
         assert representation == expected_representation
 
     def test_read_source_with_context(self):
-        representation = SerializerWithPresentable(
-            self.instance, context={"request": MockRequest}
-        )
+        representation = SerializerWithPresentable(self.instance)
         expected_representation = [PresentationSerializer(x).data for x in MockObject().foo_property]
         assert representation.data['test_many_field'] == expected_representation
         assert representation.data['test_function_field'] == expected_representation

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -14,10 +14,20 @@ class PresentationSerializer(serializers.Serializer):
 
 
 class SerializerWithPresentable(serializers.Serializer):
+    test_many_field = PresentablePrimaryKeyRelatedField(
+        queryset=MockQueryset([]),
+        presentation_serializer=PresentationSerializer,
+        read_source="foo_property", many=True
+    )
+    test_function_field = PresentablePrimaryKeyRelatedField(
+        queryset=MockQueryset([]),
+        presentation_serializer=PresentationSerializer,
+        read_source="foo_function", many=True
+    )
     test_field = PresentablePrimaryKeyRelatedField(
         queryset=MockQueryset([MockObject(pk=1, name="foo")]),
         presentation_serializer=PresentationSerializer,
-        read_source="foo_property", many=True
+        read_source="bar_property", many=False
     )
 
 
@@ -40,12 +50,16 @@ class TestPresentablePrimaryKeyRelatedField(APISimpleTestCase):
         expected_representation = PresentationSerializer(self.instance).data
         assert representation == expected_representation
 
-    def test_read_source(self):
+    def test_read_source_with_context(self):
         representation = SerializerWithPresentable(
             self.instance, context={"request": MockRequest}
-        ).data['test_field']
+        )
         expected_representation = [PresentationSerializer(x).data for x in MockObject().foo_property]
-        assert representation == expected_representation
+        assert representation.data['test_many_field'] == expected_representation
+        assert representation.data['test_function_field'] == expected_representation
+
+        expected_representation = PresentationSerializer(MockObject().bar_property).data
+        assert representation.data['test_field'] == expected_representation
 
 
 class TestPresentableSlugRelatedField(APISimpleTestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,6 +15,16 @@ class MockObject(object):
         ])
         return '<MockObject %s>' % kwargs_str
 
+    @property
+    def foo_property(self):
+        return MockQueryset(
+            [
+                MockObject(pk=3, name="foo"),
+                MockObject(pk=1, name="bar"),
+                MockObject(pk=2, name="baz"),
+            ]
+        )
+
 
 class MockQueryset(object):
     def __init__(self, iterable):
@@ -28,3 +38,23 @@ class MockQueryset(object):
             ]):
                 return item
         raise ObjectDoesNotExist()
+
+    def __iter__(self):
+        return MockIterator(self.items)
+
+
+class MockIterator:
+    def __init__(self, items):
+        self.items = items
+        self.index = 0
+
+    def __next__(self):
+        if self.index >= len(self.items):
+            raise StopIteration
+
+        self.index += 1
+        return self.items[self.index - 1]
+
+
+class MockRequest(object):
+    method = "GET"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,7 +61,3 @@ class MockIterator:
 
         self.index += 1
         return self.items[self.index - 1]
-
-
-class MockRequest(object):
-    method = "GET"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,6 +25,13 @@ class MockObject(object):
             ]
         )
 
+    def foo_function(self):
+        return self.foo_property
+
+    @property
+    def bar_property(self):
+        return MockObject(pk=3, name="foo")
+
 
 class MockQueryset(object):
     def __init__(self, iterable):


### PR DESCRIPTION
With this parameter and GET request, serializer field response to read_source parameter. For instance

`PresentablePrimaryKeyRelatedField(read_source="x_property", .......)`

will behave normally on not GET request but on GET request, it will use models "x_property"

related issue: #136