### PR TITLE
Add support for presentation_serializer="self"

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ serializer = RangeSerializer(data={'ranges': {'lower': datetime.datetime(2015, 1
 
 Represents related object with a serializer.
 
+`presentation_serializer` could also be a string that represents a dotted path of a serializer, this is useful when you want to represent a related field with the same serializer.
+
 ```python
 from drf_extra_fields.relations import PresentablePrimaryKeyRelatedField
 

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from django.utils.module_loading import import_string
 from rest_framework.relations import PrimaryKeyRelatedField, SlugRelatedField
 
 
@@ -39,14 +40,12 @@ class PresentableRelatedFieldMixin(object):
         return OrderedDict([(item.pk, self.display_value(item)) for item in queryset])
 
     def to_representation(self, data):
+        if isinstance(self.presentation_serializer, str):
+            self.presentation_serializer = import_string(self.presentation_serializer)
+
         return self.presentation_serializer(
             data, context=self.context, **self.presentation_serializer_kwargs
         ).data
-
-    def bind(self, field_name, parent):
-        if self.presentation_serializer == "self":
-            self.presentation_serializer = parent.__class__
-        super(PresentableRelatedFieldMixin, self).bind(field_name, parent)
 
 
 class PresentablePrimaryKeyRelatedField(

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -43,6 +43,11 @@ class PresentableRelatedFieldMixin(object):
             data, context=self.context, **self.presentation_serializer_kwargs
         ).data
 
+    def bind(self, field_name, parent):
+        if self.presentation_serializer == "self":
+            self.presentation_serializer = parent.__class__
+        super(PresentableRelatedFieldMixin, self).bind(field_name, parent)
+
 
 class PresentablePrimaryKeyRelatedField(
     PresentableRelatedFieldMixin, PrimaryKeyRelatedField

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -41,6 +41,7 @@ class SerializerWithPresentable(serializers.Serializer):
         queryset=MockQueryset([MockObject(pk=1, name="foo")]),
         presentation_serializer=PresentationSerializer,
         read_source="bar_property", many=False
+    )
 
 
 class TestPresentablePrimaryKeyRelatedField(APISimpleTestCase):

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -13,6 +13,14 @@ class PresentationSerializer(serializers.Serializer):
         return {"pk": instance.pk, "name": instance.name}
 
 
+class RecursiveSerializer(serializers.Serializer):
+    pk = serializers.CharField()
+    recursive_field = PresentablePrimaryKeyRelatedField(
+        queryset=MockQueryset([]),
+        presentation_serializer="tests.test_relations.RecursiveSerializer",
+    )
+
+
 class TestPresentablePrimaryKeyRelatedField(APISimpleTestCase):
     def setUp(self):
         self.queryset = MockQueryset(
@@ -56,13 +64,6 @@ class TestPresentableSlugRelatedField(APISimpleTestCase):
 
 
 class TestRecursivePresentablePrimaryKeyRelatedField(APISimpleTestCase):
-    class RecursiveSerializer(serializers.Serializer):
-        pk = serializers.CharField()
-        recursive_field = PresentablePrimaryKeyRelatedField(
-            queryset=MockQueryset([]),
-            presentation_serializer="self",
-        )
-
     def setUp(self):
         self.related_object = MockObject(
             pk=3,
@@ -78,7 +79,7 @@ class TestRecursivePresentablePrimaryKeyRelatedField(APISimpleTestCase):
         )
 
     def test_recursive(self):
-        serializer = self.RecursiveSerializer(self.related_object)
+        serializer = RecursiveSerializer(self.related_object)
         assert serializer.data == {
             'pk': '3', 'recursive_field': {
                 'pk': '4', 'recursive_field': {

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -19,6 +19,11 @@ class RecursiveSerializer(serializers.Serializer):
         queryset=MockQueryset([]),
         presentation_serializer="tests.test_relations.RecursiveSerializer",
     )
+    recursive_fields = PresentablePrimaryKeyRelatedField(
+        queryset=MockQueryset([]),
+        presentation_serializer="tests.test_relations.RecursiveSerializer",
+        many=True
+    )
 
 
 class TestPresentablePrimaryKeyRelatedField(APISimpleTestCase):
@@ -68,22 +73,46 @@ class TestRecursivePresentablePrimaryKeyRelatedField(APISimpleTestCase):
         self.related_object = MockObject(
             pk=3,
             name="baz",
+            recursive_fields=[
+                MockObject(pk=6, name="foo", recursive_fields=[], recursive_field=None),
+                MockObject(pk=7, name="baz", recursive_fields=[], recursive_field=None)
+            ],
             recursive_field=MockObject(
                 pk=4,
                 name="foobar",
+                recursive_fields=[],
                 recursive_field=MockObject(
                     pk=5,
                     name="barbaz",
-                    recursive_field=None)
+                    recursive_fields=[],
+                    recursive_field=None
+                )
             ),
         )
 
     def test_recursive(self):
         serializer = RecursiveSerializer(self.related_object)
         assert serializer.data == {
-            'pk': '3', 'recursive_field': {
-                'pk': '4', 'recursive_field': {
-                    'pk': '5', 'recursive_field': None
+            'pk': '3',
+            'recursive_field': {
+                'pk': '4',
+                'recursive_field': {
+                    'pk': '5',
+                    'recursive_field': None,
+                    'recursive_fields': []
+                },
+                'recursive_fields': []
+            },
+            'recursive_fields': [
+                {
+                    'pk': '6',
+                    'recursive_field': None,
+                    'recursive_fields': []
+                },
+                {
+                    'pk': '7',
+                    'recursive_field': None,
+                    'recursive_fields': []
                 }
-            }
+            ]
         }


### PR DESCRIPTION
#128

Add support for recursive field with `presentation_serializer="self"`.
Does not support `many=True` unfortunately.

Thanks @cobang for his helps.