### PR TITLE
Allow non-primitive values in "initial" field in range fields

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -221,6 +221,10 @@ class RangeField(DictField):
                 'upper': upper,
                 'bounds': value._bounds}
 
+    def get_initial(self):
+        initial = super().get_initial()
+        return self.to_representation(initial)
+
 
 class IntegerRangeField(RangeField):
     child = IntegerField()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -418,7 +418,7 @@ class DateTimeRangeSerializer(serializers.Serializer):
 
 class DateRangeSerializer(serializers.Serializer):
 
-    range = DateRangeField()
+    range = DateRangeField(initial=DateRange(None, None))
 
 
 class DecimalRangeSerializer(serializers.Serializer):
@@ -732,6 +732,10 @@ class TestDateRangeField(FieldValues):
             "The `source` argument is not meaningful when applied to a `child=` field. "
             "Remove `source=` from the field declaration."
         )
+
+    def test_initial_value_of_field(self):
+        serializer = DateRangeSerializer()
+        assert serializer.data['range'] == {'lower': None, 'upper': None, 'bounds': '[)'}
 
 
 class EmailSerializer(serializers.Serializer):


### PR DESCRIPTION
Related issue: #117 

Non-primitive types such as `DateRange` are not allowed in `initial` field in range fields. By overriding `get_initial` method handles this problem.