### PR TITLE
Update Django versions to test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,14 +8,13 @@ python =
 [tox]
 envlist =
     flake8,
-    py{37,38,39,310}-drf3-django{22,30,31,32}
+    py{37,38,39,310}-drf3-django{22,32,40}
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
     drf3: djangorestframework>=3
     -r requirements_dev.txt
 commands =


### PR DESCRIPTION
Django 3.0 and 3.1 are EOL, and 4.0 is the latest stable release now.

https://www.djangoproject.com/download/