### PR TITLE
Modernize the code for Python 3.7

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -35,7 +35,7 @@ except ImportError:
 DEFAULT_CONTENT_TYPE = "application/octet-stream"
 
 
-class Base64FieldMixin(object):
+class Base64FieldMixin:
     EMPTY_VALUES = (None, "", [], (), {})
 
     @property
@@ -53,7 +53,7 @@ class Base64FieldMixin(object):
     def __init__(self, *args, **kwargs):
         self.trust_provided_content_type = kwargs.pop("trust_provided_content_type", False)
         self.represent_in_base64 = kwargs.pop("represent_in_base64", False)
-        super(Base64FieldMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def to_internal_value(self, base64_data):
         # Check if this is a base64 string
@@ -91,9 +91,9 @@ class Base64FieldMixin(object):
                 content_type=file_mime_type
             )
 
-            return super(Base64FieldMixin, self).to_internal_value(data)
+            return super().to_internal_value(data)
 
-        raise ValidationError(_("Invalid type. This is not an base64 string: {}".format(type(base64_data))))
+        raise ValidationError(_(f"Invalid type. This is not an base64 string: {type(base64_data)}"))
 
     def get_file_extension(self, filename, decoded_file):
         raise NotImplementedError
@@ -114,9 +114,9 @@ class Base64FieldMixin(object):
                 with open(file.path, "rb") as f:
                     return base64.b64encode(f.read()).decode()
             except Exception:
-                raise IOError("Error encoding file")
+                raise OSError("Error encoding file")
         else:
-            return super(Base64FieldMixin, self).to_representation(file)
+            return super().to_representation(file)
 
 
 class Base64ImageField(Base64FieldMixin, ImageField):
@@ -145,7 +145,7 @@ class Base64ImageField(Base64FieldMixin, ImageField):
         if extension is None:
             try:
                 image = Image.open(io.BytesIO(decoded_file))
-            except (OSError, IOError):
+            except OSError:
                 raise ValidationError(self.INVALID_FILE_MESSAGE)
 
             extension = image.format.lower()
@@ -206,7 +206,7 @@ class RangeField(DictField):
 
         self.child_attrs = kwargs.pop("child_attrs", {})
         self.child = self.child_class(**self.default_child_attrs, **self.child_attrs)
-        super(RangeField, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def to_internal_value(self, data):
         """
@@ -221,7 +221,7 @@ class RangeField(DictField):
         if hasattr(self, "allow_empty") and not self.allow_empty and len(data) == 0:
             self.fail('empty')
 
-        extra_content = list(set(data) - set(["lower", "upper", "bounds", "empty"]))
+        extra_content = list(set(data) - {"lower", "upper", "bounds", "empty"})
         if extra_content:
             self.fail('too_much_content', extra=', '.join(map(str, extra_content)))
 
@@ -322,9 +322,9 @@ class LowercaseEmailField(EmailField):
     case-insensitive serialization and deserialization of e-mail addresses.
     """
     def to_internal_value(self, data):
-        data = super(LowercaseEmailField, self).to_internal_value(data)
+        data = super().to_internal_value(data)
         return data.lower()
 
     def to_representation(self, value):
-        value = super(LowercaseEmailField, self).to_representation(value)
+        value = super().to_representation(value)
         return value.lower()

--- a/drf_extra_fields/geo_fields.py
+++ b/drf_extra_fields/geo_fields.py
@@ -29,7 +29,7 @@ class PointField(serializers.Field):
     def __init__(self, *args, **kwargs):
         self.str_points = kwargs.pop('str_points', False)
         self.srid = kwargs.pop('srid', None)
-        super(PointField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def to_internal_value(self, value):
         """
@@ -49,9 +49,9 @@ class PointField(serializers.Field):
             try:
                 latitude = value.get("latitude")
                 longitude = value.get("longitude")
-                return GEOSGeometry('POINT(%(longitude)s %(latitude)s)' % {
-                    "longitude": longitude,
-                    "latitude": latitude},
+                return GEOSGeometry('POINT({longitude} {latitude})'.format(
+                    longitude=longitude,
+                    latitude=latitude),
                                     srid=self.srid
                 )
             except (GEOSException, ValueError):

--- a/drf_extra_fields/geo_fields.py
+++ b/drf_extra_fields/geo_fields.py
@@ -49,11 +49,9 @@ class PointField(serializers.Field):
             try:
                 latitude = value.get("latitude")
                 longitude = value.get("longitude")
-                return GEOSGeometry('POINT({longitude} {latitude})'.format(
-                    longitude=longitude,
-                    latitude=latitude),
-                                    srid=self.srid
-                )
+
+                return GEOSGeometry(f"POINT({longitude} {latitude})", srid=self.srid)
+
             except (GEOSException, ValueError):
                 self.fail('invalid')
         self.fail('invalid')

--- a/drf_extra_fields/relations.py
+++ b/drf_extra_fields/relations.py
@@ -7,7 +7,7 @@ from rest_framework.relations import (
 )
 
 
-class ReadSourceMixin(object):
+class ReadSourceMixin:
     """
     This mixin override get_attribute method and set read_source attribute
     to source attribute if read_source attribute setted. For the purpose of
@@ -56,7 +56,7 @@ class PresentableRelatedFieldMixin(ReadSourceMixin):
             self.__class__.__name__
             + " must provide a `presentation_serializer` argument"
         )
-        super(PresentableRelatedFieldMixin, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def use_pk_only_optimization(self):
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,5 +2,4 @@ Pillow >= 6.2.1
 pytest-django
 pytest-cov
 psycopg2-binary
-mock
 flake8

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -10,7 +10,7 @@ import pytest
 import pytz
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
-from mock import patch
+from unittest.mock import patch
 from psycopg2._range import NumericRange, DateTimeTZRange, DateRange
 from rest_framework import serializers
 from rest_framework.fields import DecimalField
@@ -39,7 +39,7 @@ UNDETECTABLE_BY_IMGHDR_SAMPLE = """data:image/jpeg;base64,
 /rs8AuA8VAe0vdl7VOYn+27flGAUgmITjbhSmCg3BYlyeWDkMolvw4KOp1KM6iCNvngZHwetf//Z """
 
 
-class UploadedBase64Image(object):
+class UploadedBase64Image:
     def __init__(self, file=None, created=None):
         self.file = file
         self.created = created or datetime.datetime.now()
@@ -49,8 +49,8 @@ class UploadedBase64File(UploadedBase64Image):
     pass
 
 
-class DownloadableBase64Image(object):
-    class ImageFieldFile(object):
+class DownloadableBase64Image:
+    class ImageFieldFile:
         def __init__(self, path):
             self.path = path
 
@@ -58,8 +58,8 @@ class DownloadableBase64Image(object):
         self.image = self.ImageFieldFile(path=image_path)
 
 
-class DownloadableBase64File(object):
-    class FieldFile(object):
+class DownloadableBase64File:
+    class FieldFile:
         def __init__(self, path):
             self.path = path
 
@@ -270,7 +270,7 @@ class Base64FileSerializerTests(TestCase):
             os.remove('im.jpg')
 
 
-class SavePoint(object):
+class SavePoint:
     def __init__(self, point=None, created=None):
         self.point = point
         self.created = created or datetime.datetime.now()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 
 
-class MockObject(object):
+class MockObject:
     def __init__(self, **kwargs):
         self._kwargs = kwargs
         for key, val in kwargs.items():
@@ -10,7 +10,7 @@ class MockObject(object):
 
     def __str__(self):
         kwargs_str = ', '.join([
-            '%s=%s' % (key, value)
+            f'{key}={value}'
             for key, value in sorted(self._kwargs.items())
         ])
         return '<MockObject %s>' % kwargs_str
@@ -33,7 +33,7 @@ class MockObject(object):
         return MockObject(pk=3, name="foo")
 
 
-class MockQueryset(object):
+class MockQueryset:
     def __init__(self, iterable):
         self.items = iterable
 


### PR DESCRIPTION
* Applies `pyupgrade --py37-plus`
* Removed `mock` from `requirements_dev.txt` (replaced by unittest.mock)
* Simplify string formatting with a f-string