### PR TITLE
Remove Python 3.11 deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
 	python3.8 \
 	python3.9 \
 	python3.10 \
+        python3.11 \
 	gdal-bin \
 	python3-pip
 

--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -1,6 +1,6 @@
 import base64
 import binascii
-import imghdr
+import filetype
 import io
 import uuid
 
@@ -138,10 +138,10 @@ class Base64ImageField(Base64FieldMixin, ImageField):
             from PIL import Image
         except ImportError:
             raise ImportError("Pillow is not installed.")
-        extension = imghdr.what(filename, decoded_file)
+        extension = filetype.guess_extension(decoded_file)
 
-        # Try with PIL as fallback if format not detected due
-        # to bug in imghdr https://bugs.python.org/issue16512
+        # Try with PIL as fallback if format not detected
+        # with `filetype` module
         if extension is None:
             try:
                 image = Image.open(io.BytesIO(decoded_file))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django >= 2.2
 djangorestframework >= 3.9.2
+filetype >= 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,7 +2,7 @@ import base64
 import copy
 import datetime
 import django
-import imghdr
+import filetype
 import os
 from decimal import Decimal
 
@@ -29,7 +29,7 @@ from drf_extra_fields.fields import (
 from drf_extra_fields.geo_fields import PointField
 from drf_extra_fields import compat
 
-UNDETECTABLE_BY_IMGHDR_SAMPLE = """data:image/jpeg;base64,
+UNDETECTABLE_BY_FILETYPE_SAMPLE = """data:image/jpeg;base64,
 /9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD
 /2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAAQABADASIAAhEBAxEB
 /8QAFgABAQEAAAAAAAAAAAAAAAAABwQF/8QAJBAAAQQBBAICAwAAAAAAAAAAAQIDBAYFBwgSExEiABQJMTL/xAAVAQEBAAAAAAAAAAAAAAAAAAAABv
@@ -142,16 +142,16 @@ class Base64ImageSerializerTests(TestCase):
         self.assertEqual(serializer.validated_data['created'], uploaded_image.created)
         self.assertIsNone(serializer.validated_data['file'])
 
-    def test_fallback_to_pil_if_not_detected_by_imghdr(self):
+    def test_fallback_to_pil_if_not_detected_by_filetype(self):
         """
-        Passing a sample image which goes undetected by imghdr should
+        Passing a sample image which goes undetected by filetype should
         still be detected by PIL.
         """
         now = datetime.datetime.now()
-        file = UNDETECTABLE_BY_IMGHDR_SAMPLE
+        file = UNDETECTABLE_BY_FILETYPE_SAMPLE
 
-        # check image is undetectable by imghdr
-        self.assertIsNone(imghdr.what('test.jpeg', base64.b64decode(file)))
+        # check image is undetectable by filetype
+        self.assertIsNone(filetype.guess_extension(base64.b64decode(file)))
 
         uploaded_image = UploadedBase64Image(file=file, created=now)
         serializer = UploadedBase64ImageSerializer(instance=uploaded_image, data={'created': now, 'file': file})

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,13 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [tox]
 envlist =
     flake8,
     py{37,38,39,310}-drf3-django{22,32}
-    py{38,39,310}-drf3-django{40}
+    py{38,39,310,311}-drf3-django{40}
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR resolves #185 by replacing `imghdr` with the tiny and dependency free `filetype` module. The module was selected from the recommendations listed in PEP-594.

Additionally, tests have been extended to including Python 3.11 coverage in order to validate that this resolves the `DeprecationWarning`.

External references: [PEP-594](https://peps.python.org/pep-0594/#imghdr)