### PR TITLE
Add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 .tox/
 .cache/
 venv/
+.venv
 .vscode/
 .coverage
 coverage.xml


### PR DESCRIPTION
[VirtualFish](https://virtualfish.readthedocs.io/en/latest/plugins.html#auto-activation-auto-activation) uses `.venv` files to auto-detect virtual environments.