### PR TITLE
Prevent `tzdata` from asking for input and hanging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM ubuntu:latest
 RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
 
+ARG DEBIAN_FRONTEND=noninteractive  # to prevent tzdata from asking for input and hanging #193
+
 RUN apt-get update && apt-get install -y \
 	python3.7 \
 	python3.8 \


### PR DESCRIPTION
Fixes #193

`tzdata` output with this update:

```
Setting up tzdata (2023c-0ubuntu0.22.04.1) ...

Current default time zone: 'Etc/UTC'
Local time is now:      Mon May 22 11:49:31 UTC 2023.
Universal Time is now:  Mon May 22 11:49:31 UTC 2023.
Run 'dpkg-reconfigure tzdata' if you wish to change it.
```