### PR TITLE
Use built-in 'open' method for file object

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -111,7 +111,7 @@ class Base64FieldMixin:
                 return ""
 
             try:
-                with open(file.path, "rb") as f:
+                with file.open() as f:
                     return base64.b64encode(f.read()).decode()
             except Exception:
                 raise OSError("Error encoding file")

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -44,6 +44,9 @@ class DownloadableBase64Image:
         def __init__(self, path):
             self.path = path
 
+        def open(self):
+            return open(self.path, "rb")
+
     def __init__(self, image_path):
         self.image = self.ImageFieldFile(path=image_path)
 
@@ -52,6 +55,9 @@ class DownloadableBase64File:
     class FieldFile:
         def __init__(self, path):
             self.path = path
+
+        def open(self):
+            return open(self.path, "rb")
 
     def __init__(self, file_path):
         self.file = self.FieldFile(path=file_path)


### PR DESCRIPTION
This commit changes the way we open the file in the base64 encoding operation. Instead of using Python's built-in 'open' function with the file's path, we now utilize the 'open' method provided by the file object itself. This modification makes our code more flexible, enabling it to work with file-like objects that might not have a direct filesystem path.