### PR TITLE
Support Python 3.12 and Django 5.1/5.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Extra Fields for Django Rest Framework
 
 Latest Changes
 ==============
+- **Unreleased**
+  - `Python 3.7` is no longer supported.
+  - `Python 3.12` is now supported.
+  - `Django 5.1` and `5.2` are now supported.
 - **v3.7.0**
   - `psycopg` (psycopg 3) is now supported and it's used automatically instead of `psycopg2` if available.
 - **v3.6.0**

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 Pillow >= 6.2.1
 pytest-django
 pytest-cov
+pytz
 flake8

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author='hipo',
     author_email='pypi@hipolabs.com',
     url='https://github.com/Hipo/drf-extra-fields',
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=requirements,
     classifiers=[
         'Environment :: Web Environment',
@@ -37,7 +37,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [tox]
 envlist =
@@ -12,7 +13,8 @@ envlist =
     py{37,38,39,310}-drf3-django{22,32}-psycopg2
     py{38,39,310}-drf3-django40-psycopg2
     py{38,39,310,311}-drf3-django{41,42}-psycopg2
-    py{38,39,310,311}-drf3-django42-psycopg3
+    py{38,39,310,311,312}-drf3-django42-psycopg3
+    py{310,311,312}-drf3-django{51,52}-psycopg3
 
 [testenv]
 deps =
@@ -21,6 +23,8 @@ deps =
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
     drf3: djangorestframework>=3
     psycopg2: psycopg2-binary
     psycopg3: psycopg[binary]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
@@ -10,7 +9,7 @@ python =
 [tox]
 envlist =
     flake8,
-    py{37,38,39,310}-drf3-django{22,32}-psycopg2
+    py{38,39,310}-drf3-django{22,32}-psycopg2
     py{38,39,310}-drf3-django40-psycopg2
     py{38,39,310,311}-drf3-django{41,42}-psycopg2
     py{38,39,310,311,312}-drf3-django42-psycopg3


### PR DESCRIPTION
- Drop support for end-of-life Python 3.7 (no longer supported directly by GitHub Actions)
- Support Python 3.12
- Support Django 5.1
- Support Django 5.2