### PR TITLE
feat: add QR code fields and unit tests

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -316,3 +316,166 @@ class LowercaseEmailField(EmailField):
     def to_representation(self, value):
         value = super().to_representation(value)
         return value.lower()
+
+class BaseQRCodeField(ImageField):
+    """
+    Field for generating QR codes from text input.
+    Receives text from client and converts it to QR code image.
+    """
+
+    def to_internal_value(self, data):
+        if not data:
+            raise ValidationError("Cannot generate QR code from empty text")
+            
+        if not isinstance(data, str):
+            raise ValidationError("Expected text to generate QR code")
+            
+        try:
+            import qrcode
+        except ImportError:
+            raise ImportError("qrcode library is required. Please install it using 'pip install qrcode'.")
+
+        qr = qrcode.QRCode()
+        qr.add_data(data)
+        qr.make()
+        qr_image = qr.make_image()
+        
+        buffer = io.BytesIO()
+        qr_image.save(buffer, format='PNG')
+        
+        file_name = f"qrcode_{uuid.uuid4()}.png"
+        uploaded_file = SimpleUploadedFile(
+            name=file_name,
+            content=buffer.getvalue(),
+            content_type='image/png'
+        )
+        
+        return super().to_internal_value(uploaded_file)
+
+    def to_representation(self, value):
+        return super().to_representation(value)
+
+
+class WiFiQRCodeField(BaseQRCodeField):
+    """
+    Generate a WiFi QR code from a credentials dictionary.
+
+    Expected input:
+        {
+            "ssid": str,
+            "password": str,          # optional if security == "nopass"
+            "security": "WPA"|"WEP"|"nopass",
+            "hidden": bool            # optional, defaults to False
+        }
+    """
+
+    VALID_SECURITY_VALUES = {"WPA", "WEP", "NOPASS"}
+
+    def _ensure_string(self, value, field_name):
+        if not isinstance(value, str):
+            raise ValidationError(f"Field '{field_name}' must be a string")
+        if value == "":
+            raise ValidationError(f"Field '{field_name}' cannot be empty")
+        return value
+
+    def _escape(self, text: str) -> str:
+        # Escape reserved characters according to WiFi QR specification
+        return (
+            text.replace("\\", "\\\\")
+            .replace(";", "\\;")
+            .replace(",", "\\,")
+            .replace(":", "\\:")
+            .replace('"', '\\"')
+        )
+
+    def to_internal_value(self, data):
+        if data in (None, ""):
+            raise ValidationError("Cannot generate WiFi QR from empty data")
+
+        if not isinstance(data, dict):
+            raise ValidationError("Expected a dictionary with WiFi credentials")
+
+        ssid = data.get("ssid")
+        security = data.get("security")
+        hidden = data.get("hidden", False)
+        password = data.get("password")
+
+        ssid = self._ensure_string(ssid, "ssid")
+
+        if not isinstance(security, str) or security.strip() == "":
+            raise ValidationError("Field 'security' must be a non-empty string")
+
+        security_norm = security.strip().upper()
+        if security_norm not in self.VALID_SECURITY_VALUES:
+            raise ValidationError("Field 'security' must be one of: WPA, WEP, nopass")
+
+        if not isinstance(hidden, bool):
+            raise ValidationError("Field 'hidden' must be a boolean if provided")
+
+        if security_norm != "NOPASS":
+            password = self._ensure_string(password, "password")
+        else:
+            password = None
+
+        parts = [f"WIFI:T:{'nopass' if security_norm == 'NOPASS' else security_norm}", f"S:{self._escape(ssid)}"]
+        if password is not None:
+            parts.append(f"P:{self._escape(password)}")
+        if hidden:
+            parts.append("H:true")
+
+        wifi_payload = ";".join(parts) + ";;"
+        return super().to_internal_value(wifi_payload)
+    
+class vCardQRCodeField(BaseQRCodeField):
+    """
+    Generates a QR code with contact information. Validates name, phone number, and email
+
+    expected input:
+    {
+        "name": str,
+        "phone": str,
+        "email": str
+    }
+    """
+    def to_internal_value(self, data):
+        if data in (None, ""):
+            raise ValidationError("Cannot generate vCard QR from empty data")
+            
+        if not isinstance(data, dict):
+            raise ValidationError("Expected a dictionary with vCard credentials")
+
+        name = data.get("name")
+        phone = data.get("phone")
+        email = data.get("email")
+
+        if not name or not phone or not email:
+            missing_fields = []
+            if not name:
+                missing_fields.append("name")
+            if not phone:
+                missing_fields.append("phone")
+            if not email:
+                missing_fields.append("email")
+            raise ValidationError(f"Required fields are missing: {', '.join(missing_fields)}")
+
+        vcard_content = f"BEGIN:VCARD\nVERSION:3.0\nN:{name}\nFN:{name}\nTEL;TYPE=CELL:{phone}\nEMAIL:{email}\nEND:VCARD"
+        
+        return super().to_internal_value(vcard_content)
+    
+class UrlQRCodeField(BaseQRCodeField):
+    """
+    Specialized field that generates a QR code only for URLs.
+    Validates that the URL begins with http:// or https:// before generating the QR code.
+    """
+
+    def to_internal_value(self, data):
+        if not data:
+            raise ValidationError("A QR code cannot be generated from an empty URL")
+
+        if not isinstance(data, str):
+            raise ValidationError("A text string (URL) was expected")
+
+        if not data.startswith(("http://", "https://")):
+            raise ValidationError("The URL must begin with 'http://' or 'https://'")
+
+        return super().to_internal_value(data)

--- a/tests/test_qr.py
+++ b/tests/test_qr.py
@@ -1,0 +1,256 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.exceptions import ValidationError
+from drf_extra_fields.fields import (
+    BaseQRCodeField,
+    UrlQRCodeField,
+    WiFiQRCodeField,
+    vCardQRCodeField,
+    )
+
+from rest_framework.serializers import Serializer
+from rest_framework.exceptions import ValidationError as DRFValidationError
+from PIL import Image
+
+# --- Test for BaseQRCodeField ---
+@pytest.fixture
+def qr_field():
+    """Fixture para instanciar la clase BaseQRCodeField."""
+    return BaseQRCodeField()
+
+
+def test_qrcode_field_valid(qr_field):
+    """Caso exitoso: debe generar un archivo PNG válido cuando se le pasa un string."""
+    text = "Hola Gerardo"
+    file = qr_field.to_internal_value(text)
+
+    # Verificamos que el resultado sea un archivo subido válido
+    assert isinstance(file, SimpleUploadedFile)
+    assert file.content_type == "image/png"
+    assert file.name.startswith("qrcode_")
+    assert file.name.endswith(".png")
+    assert file.size > 0  # El archivo no está vacío
+
+
+def test_qrcode_field_invalid_type(qr_field):
+    with pytest.raises(ValidationError) as exc_info:
+        qr_field.to_internal_value(12345)
+
+    assert str(exc_info.value) == "['Expected text to generate QR code']"
+
+
+def test_qrcode_field_empty_string(qr_field):
+    with pytest.raises(ValidationError) as exc_info:
+        qr_field.to_internal_value("")
+
+    assert str(exc_info.value) == "['Cannot generate QR code from empty text']"
+
+
+# --- Tests for UrlQRCodeField ---
+
+class UrlQRCodeFieldTestSerializer(Serializer):
+    qr = UrlQRCodeField()
+
+@pytest.fixture
+def url_serializer():
+    return UrlQRCodeFieldTestSerializer
+
+def test_valid_url_generates_qr(url_serializer):
+    data = {"qr": "https://www.example.com"}
+    serializer = url_serializer(data=data)
+    assert serializer.is_valid(), serializer.errors
+
+    qr_file = serializer.validated_data["qr"]
+    assert qr_file.name.endswith(".png")
+
+    image = Image.open(qr_file)
+    assert image.format == "PNG"
+
+def test_invalid_url_scheme(url_serializer):
+    data = {"qr": "ftp://example.com"}
+    serializer = url_serializer(data=data)
+    assert not serializer.is_valid()
+    assert "qr" in serializer.errors
+    assert "The URL must begin with" in str(serializer.errors["qr"][0])
+
+def test_empty_url(url_serializer):
+    data = {"qr": ""}
+    serializer = url_serializer(data=data)
+    assert not serializer.is_valid()
+    assert "qr" in serializer.errors
+    assert "cannot be generated from an empty URL" in str(serializer.errors["qr"][0])
+
+def test_non_string_input(url_serializer):
+    data = {"qr": 12345}
+    serializer = url_serializer(data=data)
+    assert not serializer.is_valid()
+    assert "qr" in serializer.errors
+    assert "A text string (URL) was expected" in str(serializer.errors["qr"][0])
+
+# --- test for WIFIQRCodeField ---
+
+@pytest.fixture
+def wifi_field():
+    return WiFiQRCodeField()
+
+
+def test_wifi_qrcode_valid_wpa(wifi_field):
+    creds = {
+        "ssid": "MyWiFi",
+        "password": "supersecret",
+        "security": "WPA",
+        "hidden": False,
+    }
+
+    file = wifi_field.to_internal_value(creds)
+
+    assert isinstance(file, SimpleUploadedFile)
+    assert file.content_type == "image/png"
+    assert file.name.startswith("qrcode_")
+    assert file.name.endswith(".png")
+    assert file.size > 0
+
+
+def test_wifi_qrcode_valid_nopass(wifi_field):
+    creds = {
+        "ssid": "PublicHotspot",
+        "security": "nopass",
+    }
+
+    file = wifi_field.to_internal_value(creds)
+
+    assert isinstance(file, SimpleUploadedFile)
+    assert file.content_type == "image/png"
+    assert file.name.endswith(".png")
+
+
+def test_wifi_qrcode_invalid_type_not_dict(wifi_field):
+    with pytest.raises(ValidationError) as exc_info:
+        wifi_field.to_internal_value("not-a-dict")
+    assert exc_info.value.messages[0] == "Expected a dictionary with WiFi credentials"
+
+
+def test_wifi_qrcode_empty_data(wifi_field):
+    with pytest.raises(ValidationError) as exc_info:
+        wifi_field.to_internal_value("")
+    assert exc_info.value.messages[0] == "Cannot generate WiFi QR from empty data"
+
+
+def test_wifi_qrcode_missing_ssid(wifi_field):
+    creds = {"security": "WPA", "password": "x"}
+    with pytest.raises(ValidationError) as exc_info:
+        wifi_field.to_internal_value(creds)
+    assert exc_info.value.messages[0] == "Field 'ssid' must be a string"
+
+
+def test_wifi_qrcode_empty_ssid(wifi_field):
+    creds = {"ssid": "", "security": "WPA", "password": "x"}
+    with pytest.raises(ValidationError) as exc_info:
+        wifi_field.to_internal_value(creds)
+    assert exc_info.value.messages[0] == "Field 'ssid' cannot be empty"
+
+
+def test_wifi_qrcode_missing_security(wifi_field):
+    creds = {"ssid": "MyWiFi", "password": "x"}
+    with pytest.raises(ValidationError) as exc_info:
+        wifi_field.to_internal_value(creds)
+    assert exc_info.value.messages[0] == "Field 'security' must be a non-empty string"
+
+
+def test_wifi_qrcode_invalid_security_value(wifi_field):
+    creds = {"ssid": "MyWiFi", "password": "x", "security": "WPA2"}
+    with pytest.raises(ValidationError) as exc_info:
+        wifi_field.to_internal_value(creds)
+    assert exc_info.value.messages[0] == "Field 'security' must be one of: WPA, WEP, nopass"
+
+
+def test_wifi_qrcode_password_required_for_wpa(wifi_field):
+    creds = {"ssid": "MyWiFi", "security": "WPA"}
+    with pytest.raises(ValidationError) as exc_info:
+        wifi_field.to_internal_value(creds)
+    assert exc_info.value.messages[0] == "Field 'password' must be a string"
+
+
+def test_wifi_qrcode_hidden_must_be_boolean(wifi_field):
+    creds = {"ssid": "MyWiFi", "password": "x", "security": "WEP", "hidden": "yes"}
+    with pytest.raises(ValidationError) as exc_info:
+        wifi_field.to_internal_value(creds)
+    assert exc_info.value.messages[0] == "Field 'hidden' must be a boolean if provided"
+
+
+def test_wifi_qrcode_escaping_characters(wifi_field):
+    creds = {
+        "ssid": "Office;Wi,fi:Net\\work\"",
+        "password": "p;,:\\\"",
+        "security": "WEP",
+        "hidden": True,
+    }
+
+    file = wifi_field.to_internal_value(creds)
+    assert isinstance(file, SimpleUploadedFile)
+
+# --- Test for vCardQRCodeFields ---
+
+@pytest.fixture
+def vcard_field():
+    return vCardQRCodeField()
+
+
+def test_vcard_qrcode_valid(vcard_field):
+    data = {
+        "name": "John Doe",
+        "phone": "+1-555-1234",
+        "email": "john@example.com",
+    }
+
+    file = vcard_field.to_internal_value(data)
+
+    assert isinstance(file, SimpleUploadedFile)
+    assert file.content_type == "image/png"
+    assert file.name.startswith("qrcode_")
+    assert file.name.endswith(".png")
+    assert file.size > 0
+
+
+def test_vcard_qrcode_invalid_type_not_dict(vcard_field):
+    with pytest.raises(ValidationError) as exc_info:
+        vcard_field.to_internal_value("not-a-dict")
+    assert exc_info.value.messages[0] == "Expected a dictionary with vCard credentials"
+
+
+def test_vcard_qrcode_empty_data(vcard_field):
+    with pytest.raises(ValidationError) as exc_info:
+        vcard_field.to_internal_value("")
+    assert exc_info.value.messages[0] == "Cannot generate vCard QR from empty data"
+
+
+def test_vcard_qrcode_missing_name(vcard_field):
+    data = {"phone": "+1-555-1234", "email": "john@example.com"}
+    with pytest.raises(ValidationError) as exc_info:
+        vcard_field.to_internal_value(data)
+    assert exc_info.value.messages[0] == "Required fields are missing: name"
+
+
+def test_vcard_qrcode_missing_phone(vcard_field):
+    data = {"name": "John Doe", "email": "john@example.com"}
+    with pytest.raises(ValidationError) as exc_info:
+        vcard_field.to_internal_value(data)
+    assert exc_info.value.messages[0] == "Required fields are missing: phone"
+
+
+def test_vcard_qrcode_missing_email(vcard_field):
+    data = {"name": "John Doe", "phone": "+1-555-1234"}
+    with pytest.raises(ValidationError) as exc_info:
+        vcard_field.to_internal_value(data)
+    assert exc_info.value.messages[0] == "Required fields are missing: email"
+
+
+def test_vcard_qrcode_multiple_missing_fields(vcard_field):
+    data = {"name": "John Doe"}
+    with pytest.raises(ValidationError) as exc_info:
+        vcard_field.to_internal_value(data)
+    # El orden de los campos faltantes sigue la lógica de construcción de la lista
+    assert exc_info.value.messages[0] in (
+        "Required fields are missing: phone, email",
+        "Required fields are missing: email, phone",
+    )


### PR DESCRIPTION
## Added custom QR code fields to drf-extra-fields and included unit tests to ensure proper functionality. The goal is to allow developers to generate QR codes from DRF serializers for common use cases such as plain text, URLs, WiFi credentials, and vCards.

## Fields Implemented

Added to drf_extra_fields/fields.py:

* BaseQRCodeField: Generic QR code generator from a string input, returns a PNG image.

* UrlQRCodeField: Generates QR codes only for valid URLs (http:// or https://).

* WiFiQRCodeField: Generates a QR code for WiFi credentials. Accepts a dictionary with ssid, password, security, and hidden.

* vCardQRCodeField: Generates a QR code containing contact information in vCard format. Accepts a dictionary with name, phone, and email.

Each field includes input validation and error handling.

## Unit Tests

A new test file tests/test_qr.py was added. Tests cover:

* QR code generation for valid inputs

* Proper handling of invalid inputs (empty strings, missing fields, invalid URLs)

* Edge cases for each field

* Verification that generated QR codes are valid PNG files

Passing Test:

<img width="1487" height="294" alt="captura_baseqr" src="https://github.com/user-attachments/assets/dc584050-ac6f-401a-adfe-05ed4d549d99" />