### PR TITLE
Add pre-commit config & action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,19 @@
+name: pre-commit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: ~
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: check-case-conflict
+    -   id: check-merge-conflict
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ class ProductSerializer(serializers.ModelSerializer):
 ```
 
 ### read_source parameter
-This parameter allows you to use different `source` for read operations and doesn't change field name for write operations. This is only used while representing the data. 
+This parameter allows you to use different `source` for read operations and doesn't change field name for write operations. This is only used while representing the data.
 
 ## HybridImageField
 A django-rest-framework field for handling image-uploads through raw post data, with a fallback to multipart form data.


### PR DESCRIPTION
Resolves #227 

I had to set Python version to `3.9` because `3.7` is not supported by Github anymore and pre-commit-hooks requires `Python >= 3.9`