### PR TITLE
Fix `INVALID_TYPE_MESSAGE` error message

### DIFF
--- a/drf_extra_fields/fields.py
+++ b/drf_extra_fields/fields.py
@@ -124,7 +124,7 @@ class Base64ImageField(Base64FieldMixin, ImageField):
         "webp"
     )
     INVALID_FILE_MESSAGE = _("Please upload a valid image.")
-    INVALID_TYPE_MESSAGE = _("The type of the image couldn't be determined.")
+    INVALID_TYPE_MESSAGE = _("The type of the image is not allowed.")
 
     def get_file_extension(self, filename, decoded_file):
         extension = filetype.guess_extension(decoded_file)


### PR DESCRIPTION
`INVALID_TYPE_MESSAGE` is used in the following block:

```py
            if file_extension not in self.ALLOWED_TYPES:
                raise ValidationError(self.INVALID_TYPE_MESSAGE)
```

The current error message is misleading because it says that the type couldn't be determined, but really the type is not _allowed_ in the `ALLOWED_TYPES`.